### PR TITLE
Adjust plural container objects to actually be arrays

### DIFF
--- a/api-specificatie/indicatieregister.yaml
+++ b/api-specificatie/indicatieregister.yaml
@@ -1161,7 +1161,7 @@ components:
           type: string
           maxLength: 255
       xml:
-        name: WlzIndicatie
+        name: wlzindicatie
     GeindiceerdeFunctie:
       required:
         - functiecode

--- a/api-specificatie/indicatieregister.yaml
+++ b/api-specificatie/indicatieregister.yaml
@@ -251,7 +251,7 @@ paths:
       tags:
         - WLZ indicaties
       summary: Vind stoornissen bij een wlzindicatieID.
-      description: Diagnostische gegevens m.b.t. ziektebeeld en/of stoornis van de client. 
+      description: Diagnostische gegevens m.b.t. ziektebeeld en/of stoornis van de client.
       operationId: getWLZindicatiestoornissen
       parameters:
         - in: header
@@ -459,7 +459,7 @@ paths:
       tags:
         - WLZ indicaties
       summary: Geeft clientgegevens op basis van het WLZ indicatie ID
-      description: Persoonsgegevens van de cliënt. 
+      description: Persoonsgegevens van de cliënt.
       operationId: getclientIO31
       parameters:
         - in: header
@@ -615,7 +615,7 @@ paths:
       operationId: getBopzbyBsn
       parameters:
         - in: header
-          name: X-orgKey  
+          name: X-orgKey
           description: Uniek ID van de organisatie binnen het netwerk
           schema:
             type: integer
@@ -667,7 +667,7 @@ paths:
       operationId: getBopz
       parameters:
         - in: header
-          name: X-orgKey  
+          name: X-orgKey
           description: Uniek ID van de organisatie binnen het netwerk
           schema:
             type: integer
@@ -719,7 +719,7 @@ paths:
       operationId: getWzdbyBsn
       parameters:
         - in: header
-          name: X-orgKey  
+          name: X-orgKey
           description: Uniek ID van de organisatie binnen het netwerk
           schema:
             type: integer
@@ -771,7 +771,7 @@ paths:
       operationId: getWzd
       parameters:
         - in: header
-          name: X-orgKey  
+          name: X-orgKey
           description: Uniek ID van de organisatie binnen het netwerk
           schema:
             type: integer
@@ -818,7 +818,7 @@ components:
   schemas:
     Adres:
       required:
-       - adresSoort
+        - adresSoort
       type: object
       properties:
         adresSoort:
@@ -826,49 +826,48 @@ components:
           type: string
           enum: ["01","02","03"]
           example: "01"
-        straatnaam: 
+        straatnaam:
           type: string
           example: "Oudaen"
         huisnummer:
           type: integer
           format: int32
           example: 19
-        huisletter: 
+        huisletter:
           type: string
         huisnummerToevoeging:
-          type: string 
-        postcode: 
+          type: string
+        postcode:
           type: string
           example: "1081BA"
-        plaatsnaam: 
+        plaatsnaam:
           type: string
           example: "Amsterdam"
-        landCode: 
+        landCode:
           description: "Moet voldoen aan COD032:Land; zie iWlz codelijsten"
           type: string
           example: "NL"
         aanduidingWoonadres:
           description: "Moet voldoen aan NUM061: Aanduiding woonadres; zie iWlz codelijsten"
-          type: string 
+          type: string
           enum: ["AB","BY","TO","WW"]
-        ingangsdatum: 
+        ingangsdatum:
           type: string
           format: date
           example: "2005-09-01"
-        einddatum: 
+        einddatum:
           type: string
-          format: date  
+          format: date
     Adressen:
-        type: object
-        properties:
-          adres:
-            $ref: '#/components/schemas/Adres'
-        xml:
-          name: adressen
-          wrapped: true
+      type: array
+      items:
+        $ref: '#/components/schemas/Adres'
+      xml:
+        name: adressen
+        wrapped: true
     Beperking:
       required:
-       - categorie
+        - categorie
       type: object
       properties:
         categorie:
@@ -884,17 +883,16 @@ components:
         commentaar:
           type: string
     Beperkingen:
-      type: object
-      properties:
-        beperking:
-          $ref: '#/components/schemas/Beperking'
+      type: array
+      items:
+        $ref: '#/components/schemas/Beperking'
       xml:
         name: beperkingen
         wrapped: true
     BeperkingScore:
       required:
-       - beperkingsVraag
-       - beperkinsScore
+        - beperkingsVraag
+        - beperkinsScore
       type: object
       properties:
         beperkingsVraag:
@@ -909,17 +907,16 @@ components:
         commentaar:
           type: string
     BeperkingScores:
-      type: object
-      properties:
-        beperkingscore:
-          $ref: '#/components/schemas/BeperkingScore'
+      type: array
+      items:
+        $ref: '#/components/schemas/BeperkingScore'
       xml:
         name: beperkingScores
         wrapped: true
     BOPZ:
       required:
-       - bsn
-       - bopzVerklaring
+        - bsn
+        - bopzVerklaring
       type: object
       properties:
         bsn:
@@ -935,12 +932,12 @@ components:
         name: bopz
     Client:
       required:
-       - bsn
-       - geheimeClient
-       - geslacht
-       - geslachtsnaam
-       - naamGebruik
-       - leefeenheid
+        - bsn
+        - geheimeClient
+        - geslacht
+        - geslachtsnaam
+        - naamGebruik
+        - leefeenheid
       type: object
       properties:
         bsn:
@@ -1012,7 +1009,7 @@ components:
           type: string
           maxLength: 255
       xml:
-        name: client   
+        name: client
     ContactGegevens:
       type: object
       properties:
@@ -1022,19 +1019,16 @@ components:
           $ref: '#/components/schemas/Telefoonnummers'
         email:
           $ref: '#/components/schemas/Emailadressen'
-      xml:
-        name: contactGegevens
-        wrapped: true
     ContactPersoon:
-      required: 
-       - soortRelatie
+      required:
+        - soortRelatie
       type: object
       properties:
         soortRelatie:
           description: "Moet voldoen aan COD472:Soort relatie; zie iWlz codelijsten"
           type: string
           enum: ["04","05","06","07","08","09","10","11","12","13","14","15","16","17","18","19","20","21","22","23","24","25"] #@@nNog verder aanvullen
-          example: "12" 
+          example: "12"
         organisatieNaam:
           type: string
         voornamen:
@@ -1069,12 +1063,12 @@ components:
           description: "Moet voldoen aan COD170:Datumgebruik; zie iWlz codelijsten"
           type: integer
           format: int32
-          enum: [1,2,3]  
-        ingangsdatum: 
+          enum: [1,2,3]
+        ingangsdatum:
           type: string
           format: date
           example: "2005-09-01"
-        einddatum: 
+        einddatum:
           type: string
           format: date
         adres:
@@ -1084,33 +1078,31 @@ components:
         email:
           $ref: '#/components/schemas/Emailadressen'
     ContactPersonen:
-      type: object
-      properties:
-        contactPersoon:
-          $ref: '#/components/schemas/ContactPersoon'
+      type: array
+      items:
+        $ref: '#/components/schemas/ContactPersoon'
       xml:
         name: contactPersonen
         wrapped: true
     Email:
       required:
-       - emailadres
+        - emailadres
       type: object
-      properties: 
+      properties:
         emailadres:
           type: string
           example: "test@testmail.nl"
-        ingangsdatum: 
+        ingangsdatum:
           type: string
           format: date
           example: "2005-09-01"
-        einddatum: 
+        einddatum:
           type: string
           format: date
     Emailadressen:
-      type: object
-      properties:
-        Email:
-          $ref: '#/components/schemas/Email'
+      type: array
+      items:
+        $ref: '#/components/schemas/Email'
       xml:
         name: emailadressen
         wrapped: true
@@ -1160,11 +1152,11 @@ components:
         name: WLZ indicatie
     GeindiceerdeFunctie:
       required:
-       - functiecode
-       - ingangsdatum
-       - klasse
-       - leveringsVoorwaarde
-       - financiering
+        - functiecode
+        - ingangsdatum
+        - klasse
+        - leveringsVoorwaarde
+        - financiering
       type: object
       properties:
         functiecode:
@@ -1197,18 +1189,17 @@ components:
         commentaar:
           type: string
     GeindiceerdeFuncties:
-      type: object
-      properties:
-        geindiceerdeFunctie:
-          $ref: '#/components/schemas/GeindiceerdeFunctie'
+      type: array
+      items:
+        $ref: '#/components/schemas/GeindiceerdeFunctie'
       xml:
         name: geindiceerdeFuncties
         wrapped: true
     GeindiceerdZorgzwaartepakket:
       required:
-       - zzpCode
-       - ingangsdatum
-       - financiering
+        - zzpCode
+        - ingangsdatum
+        - financiering
       type: object
       properties:
         zzpCode:
@@ -1238,10 +1229,9 @@ components:
         commentaar:
           type: string
     GeindiceerdeZorgzwaartepakketten:
-      type: object
-      properties:
-        geindiceerdZorgzwaartepakket:
-          $ref: '#/components/schemas/GeindiceerdZorgzwaartepakket'
+      type: array
+      items:
+        $ref: '#/components/schemas/GeindiceerdZorgzwaartepakket'
       xml:
         name: geindiceerdeZorgzwaartepakketten
         wrapped: true
@@ -1255,18 +1245,17 @@ components:
           type: string
           enum: ["01","02","03","04","05","06","07"]
     Grondslagen:
-      type: object
-      properties:
-        grondslagen:
-          $ref: '#/components/schemas/Grondslag'
+      type: array
+      items:
+        $ref: '#/components/schemas/Grondslag'
       xml:
         name: grondslag
         wrapped: true
     Stoornis:
       required:
-       - grondslag
-       - diagnoseCodelijst
-       - ziektebeeldStoornis
+        - grondslag
+        - diagnoseCodelijst
+        - ziektebeeldStoornis
       type: object
       properties:
         grondslag:
@@ -1285,24 +1274,23 @@ components:
           description: "vulling uit combinatie van COD923, COD924 en COD925; zie iWlz codelijsten"
           type: string
         prognose:
-          description: "Moet voldoen aan COD737: Progenose; zie iWlz codelijsten"       
+          description: "Moet voldoen aan COD737: Progenose; zie iWlz codelijsten"
           type: integer
           format: int32
           enum: ["1","2","3","4","5"]
         commentaar:
           type: string
     Stoornissen:
-      type: object
-      properties:
-        stoornis:
-          $ref: '#/components/schemas/Stoornis'
+      type: array
+      items:
+        $ref: '#/components/schemas/Stoornis'
       xml:
         name: stoornissen
         wrapped: true
     StoornisScore:
       required:
-       - stoornisVraag
-       - stoornisScore
+        - stoornisVraag
+        - stoornisScore
       type: object
       properties:
         stoornisVraag:
@@ -1316,16 +1304,15 @@ components:
         commentaar:
           type: string
     StoornisScores:
-      type: object
-      properties:
-        stoornisScore:
-          $ref: '#/components/schemas/StoornisScore'
+      type: array
+      items:
+        $ref: '#/components/schemas/StoornisScore'
       xml:
         name: stoornisScores
         wrapped: true
     Telefoon:
       required:
-       - telefoonnummer
+        - telefoonnummer
       type: object
       properties:
         telefoonnummer:
@@ -1334,18 +1321,17 @@ components:
         landnummer:
           type: string
           example: "31"
-        ingangsdatum: 
+        ingangsdatum:
           type: string
           format: date
           example: "2005-09-01"
-        einddatum: 
+        einddatum:
           type: string
           format: date
     Telefoonnummers:
-      type: object
-      properties:
-        telefoon:
-          $ref: '#/components/schemas/Telefoon'
+      type: array
+      items:
+        $ref: '#/components/schemas/Telefoon'
       xml:
         name: telefoonnummers
         wrapped: true
@@ -1355,31 +1341,24 @@ components:
         WLZ indicatie:
           type: string
           enum: ["Ja","Nee","Onbekend"]
-      xml:
-        name: WlzCheck
-        wrapped: true
     WlzindicatieID:
       type: object
       properties:
-        wlzindicatieID: 
+        wlzindicatieID:
           type: string
           format: uuid
           pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[4][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
-      xml: 
-        name: wlzindicatieID
-        wrapped: true
     WlzindicatieIDs:
-      type: object
-      properties:
-        wlzindicatieID:
-          $ref: '#/components/schemas/WlzindicatieID'
+      type: array
+      items:
+        $ref: '#/components/schemas/WlzindicatieID'
       xml:
         name: wlzindicatieids
-        wrapped: true    
+        wrapped: true
     WZD:
       required:
-       - bsn
-       - wzdVerklaring
+        - bsn
+        - wzdVerklaring
       type: object
       properties:
         bsn:

--- a/api-specificatie/indicatieregister.yaml
+++ b/api-specificatie/indicatieregister.yaml
@@ -858,6 +858,8 @@ components:
         einddatum:
           type: string
           format: date
+      xml:
+        name: adres
     Adressen:
       type: array
       items:
@@ -882,6 +884,8 @@ components:
           example: "1"
         commentaar:
           type: string
+      xml:
+        name: beperking
     Beperkingen:
       type: array
       items:
@@ -906,6 +910,8 @@ components:
           example: "1"
         commentaar:
           type: string
+      xml:
+        name: beperkingScore
     BeperkingScores:
       type: array
       items:
@@ -1019,6 +1025,8 @@ components:
           $ref: '#/components/schemas/Telefoonnummers'
         email:
           $ref: '#/components/schemas/Emailadressen'
+      xml:
+        name: contactGegevens
     ContactPersoon:
       required:
         - soortRelatie
@@ -1077,6 +1085,8 @@ components:
           $ref: '#/components/schemas/Telefoonnummers'
         email:
           $ref: '#/components/schemas/Emailadressen'
+      xml:
+        name: contactPersoon
     ContactPersonen:
       type: array
       items:
@@ -1099,6 +1109,8 @@ components:
         einddatum:
           type: string
           format: date
+      xml:
+        name: email
     Emailadressen:
       type: array
       items:
@@ -1149,7 +1161,7 @@ components:
           type: string
           maxLength: 255
       xml:
-        name: WLZ indicatie
+        name: WlzIndicatie
     GeindiceerdeFunctie:
       required:
         - functiecode
@@ -1188,6 +1200,8 @@ components:
           enum: ["1","2","3","4"]
         commentaar:
           type: string
+      xml:
+        name: geindiceerdeFunctie
     GeindiceerdeFuncties:
       type: array
       items:
@@ -1228,6 +1242,8 @@ components:
           enum: ["1","2","3","4"]
         commentaar:
           type: string
+      xml:
+        name: geindiceerdeZorgzwaartepakket
     GeindiceerdeZorgzwaartepakketten:
       type: array
       items:
@@ -1244,12 +1260,14 @@ components:
           description: "Moet voldoen aan COD736:Grondslag zorg; zie iWlz codelijsten"
           type: string
           enum: ["01","02","03","04","05","06","07"]
+      xml:
+        name: grondslag
     Grondslagen:
       type: array
       items:
         $ref: '#/components/schemas/Grondslag'
       xml:
-        name: grondslag
+        name: grondslagen
         wrapped: true
     Stoornis:
       required:
@@ -1280,6 +1298,8 @@ components:
           enum: ["1","2","3","4","5"]
         commentaar:
           type: string
+      xml:
+        name: stoornis
     Stoornissen:
       type: array
       items:
@@ -1303,6 +1323,8 @@ components:
           example: "1"
         commentaar:
           type: string
+      xml:
+        name: stoornisScore
     StoornisScores:
       type: array
       items:
@@ -1328,6 +1350,8 @@ components:
         einddatum:
           type: string
           format: date
+      xml:
+        name: telefoon
     Telefoonnummers:
       type: array
       items:
@@ -1341,6 +1365,8 @@ components:
         WLZ indicatie:
           type: string
           enum: ["Ja","Nee","Onbekend"]
+      xml:
+        name: WlzCheck
     WlzindicatieID:
       type: object
       properties:
@@ -1348,12 +1374,14 @@ components:
           type: string
           format: uuid
           pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[4][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+      xml:
+        name: wlzindicatieID
     WlzindicatieIDs:
       type: array
       items:
         $ref: '#/components/schemas/WlzindicatieID'
       xml:
-        name: wlzindicatieids
+        name: WlzindicatieIDs
         wrapped: true
     WZD:
       required:


### PR DESCRIPTION
Bij het implementeren van de spec liepen we er bij het CIZ tegenaan dat de, vanuit de spec, gegenereerde model objecten niet iterable waren. Hierdoor kunnen we bijvoorbeeld max één WlzindicatieID returnen. 
Door WlzindicatieIDs in de spec te markeren als een array en hiervoor de correctie syntax te implementeren is het wel mogelijk om meerdere WlzindicatieID te returnen. Deze wijziging hebben we voor alle meervoudige objecten doorgevoerd (e.g. Adressen, ContactPersonen, etc).

We hebben geprobeerd om zo min mogelijk aanpassingen te maken (excuses voor de whitespace wijzigingen).