### PR TITLE
Fix inconsistencies and spelling/casing errors

### DIFF
--- a/api-specificatie/indicatieregister.yaml
+++ b/api-specificatie/indicatieregister.yaml
@@ -132,10 +132,10 @@ paths:
           content:
             application/xml:
               schema:
-                $ref: '#/components/schemas/wlzindicatie'
+                $ref: '#/components/schemas/Wlzindicatie'
             application/json:
               schema:
-                $ref: '#/components/schemas/wlzindicatie'
+                $ref: '#/components/schemas/Wlzindicatie'
         '400':
           description: Ongeldig ID
           content: {}
@@ -972,7 +972,7 @@ components:
           enum: [1,2,3,4,5,6,7,8,9]
         geslachtsnaam:
           type: string
-        voorvoegselGeslachtnaam:
+        voorvoegselGeslachtsnaam:
           type: string
         partnernaam:
           type: string
@@ -1048,7 +1048,7 @@ components:
           type: string
         geslachtsnaam:
           type: string
-        voorvoegselGeslachtnaam:
+        voorvoegselGeslachtsnaam:
           type: string
         partnernaam:
           type: string
@@ -1118,12 +1118,12 @@ components:
       xml:
         name: emailadressen
         wrapped: true
-    wlzindicatie:
+    Wlzindicatie:
       required:
         - wlzindicatieID
         - besluitnummer
         - bsn
-        - soortWLZ indicatie
+        - soortWlzindicatie
       type: object
       properties:
         wlzindicatieID:
@@ -1138,7 +1138,7 @@ components:
           type: integer
           format: int32
           example: 1236458977
-        soortWLZ indicatie:
+        soortWlzindicatie:
           description: "Moet voldoen aan COD169: Soort WLZ indicatie; zie iWlz codelijsten"
           type: integer
           enum: ["1","2","3","4"]
@@ -1292,7 +1292,7 @@ components:
           description: "vulling uit combinatie van COD923, COD924 en COD925; zie iWlz codelijsten"
           type: string
         prognose:
-          description: "Moet voldoen aan COD737: Progenose; zie iWlz codelijsten"
+          description: "Moet voldoen aan COD737: Prognose; zie iWlz codelijsten"
           type: integer
           format: int32
           enum: ["1","2","3","4","5"]

--- a/api-specificatie/indicatieregister.yaml
+++ b/api-specificatie/indicatieregister.yaml
@@ -61,7 +61,7 @@ paths:
             format: int32
           required: true
         - in: header
-          name: X-requestID
+          name: X-Request-ID
           description: Identificatie van het request
           schema:
             type: string
@@ -113,7 +113,7 @@ paths:
             format: int32
           required: true
         - in: header
-          name: X-requestID
+          name: X-Request-ID
           description: Identificatie van het request
           schema:
             type: string
@@ -165,7 +165,7 @@ paths:
             format: int32
           required: true
         - in: header
-          name: X-requestID
+          name: X-Request-ID
           description: Identificatie van het request
           schema:
             type: string
@@ -217,7 +217,7 @@ paths:
             format: int32
           required: true
         - in: header
-          name: X-requestID
+          name: X-Request-ID
           description: Identificatie van het request
           schema:
             type: string
@@ -269,7 +269,7 @@ paths:
             format: int32
           required: true
         - in: header
-          name: X-requestID
+          name: X-Request-ID
           description: Identificatie van het request
           schema:
             type: string
@@ -321,7 +321,7 @@ paths:
             format: int32
           required: true
         - in: header
-          name: X-requestID
+          name: X-Request-ID
           description: Identificatie van het request
           schema:
             type: string
@@ -373,7 +373,7 @@ paths:
             format: int32
           required: true
         - in: header
-          name: X-requestID
+          name: X-Request-ID
           description: Identificatie van het request
           schema:
             type: string
@@ -425,7 +425,7 @@ paths:
             format: int32
           required: true
         - in: header
-          name: X-requestID
+          name: X-Request-ID
           description: Identificatie van het request
           schema:
             type: string
@@ -477,7 +477,7 @@ paths:
             format: int32
           required: true
         - in: header
-          name: X-requestID
+          name: X-Request-ID
           description: Identificatie van het request
           schema:
             type: string
@@ -527,7 +527,7 @@ paths:
             format: int32
           required: true
         - in: header
-          name: X-requestID
+          name: X-Request-ID
           description: Identificatie van het request
           schema:
             type: string
@@ -579,7 +579,7 @@ paths:
             format: int32
           required: true
         - in: header
-          name: X-requestID
+          name: X-Request-ID
           description: Identificatie van het request
           schema:
             type: string
@@ -629,7 +629,7 @@ paths:
             format: int32
           required: true
         - in: header
-          name: X-requestID
+          name: X-Request-ID
           description: Identificatie van het request
           schema:
             type: string
@@ -681,7 +681,7 @@ paths:
             format: int32
           required: true
         - in: header
-          name: X-requestID
+          name: X-Request-ID
           description: Identificatie van het request
           schema:
             type: string
@@ -733,7 +733,7 @@ paths:
             format: int32
           required: true
         - in: header
-          name: X-requestID
+          name: X-Request-ID
           description: Identificatie van het request
           schema:
             type: string
@@ -785,7 +785,7 @@ paths:
             format: int32
           required: true
         - in: header
-          name: X-requestID
+          name: X-Request-ID
           description: Identificatie van het request
           schema:
             type: string

--- a/api-specificatie/indicatieregister.yaml
+++ b/api-specificatie/indicatieregister.yaml
@@ -1252,14 +1252,9 @@ components:
         name: geindiceerdeZorgzwaartepakketten
         wrapped: true
     Grondslag:
-      required:
-        - grondslag
-      type: object
-      properties:
-        grondslag:
-          description: "Moet voldoen aan COD736:Grondslag zorg; zie iWlz codelijsten"
-          type: string
-          enum: ["01","02","03","04","05","06","07"]
+      description: "Moet voldoen aan COD736:Grondslag zorg; zie iWlz codelijsten"
+      type: string
+      enum: ["01","02","03","04","05","06","07"]
       xml:
         name: grondslag
     Grondslagen:


### PR DESCRIPTION
Tijdens het nalopen van de specificatie kwamen we een spelfout tegen in het voorvoegselGeslachtsnaam. 
Verder waren er wat inconsistenties betreffende de casing van Wlzindicatie en werd de header X-Request-ID hier anders geschreven dan in de andere iWlz specs (X-requestID i.p.v. X-Request-ID).

Ook hebben we de wrapper rond grondslag verwijderd om de structuur iets platter te maken.
Huidig:
```
	<grondslagen>
		<grondslag>
			<grondslag>01</grondslag>
		</grondslag>
	</grondslagen>
```
Wordt dan:
```
	<grondslagen>
		<grondslag>01</grondslag>
	</grondslagen>
```
