### PR TITLE
Removed object wrapper around WlzindicatieID

### DIFF
--- a/api-specificatie/indicatieregister.yaml
+++ b/api-specificatie/indicatieregister.yaml
@@ -1363,12 +1363,9 @@ components:
       xml:
         name: WlzCheck
     WlzindicatieID:
-      type: object
-      properties:
-        wlzindicatieID:
-          type: string
-          format: uuid
-          pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[4][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+      type: string
+      format: uuid
+      pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[4][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
       xml:
         name: wlzindicatieID
     WlzindicatieIDs:


### PR DESCRIPTION
Resolves #5 

De plattere structuur maakt het aan onze kant ook makkelijker om tussen objecten te mappen.
Dit is eigenlijk dezelfde wijziging als die ook al is doorgevoerd voor Grondslagen.